### PR TITLE
Fix OSM sport tag matching for multi-sport pitches

### DIFF
--- a/scripts/check_osm_coverage.py
+++ b/scripts/check_osm_coverage.py
@@ -33,9 +33,9 @@ GAA_TAGS = {"gaelic_football", "hurling", "gaelic_games"}
 def build_query(lat, lon):
     return f"""[out:json][timeout:25];
 (
-  way["sport"="gaelic_football"](around:{SEARCH_RADIUS_M},{lat},{lon});
-  way["sport"="hurling"](around:{SEARCH_RADIUS_M},{lat},{lon});
-  way["sport"="gaelic_games"](around:{SEARCH_RADIUS_M},{lat},{lon});
+  way["sport"~"gaelic_football"](around:{SEARCH_RADIUS_M},{lat},{lon});
+  way["sport"~"hurling"](around:{SEARCH_RADIUS_M},{lat},{lon});
+  way["sport"~"gaelic_games"](around:{SEARCH_RADIUS_M},{lat},{lon});
   way["leisure"="pitch"](around:{SEARCH_RADIUS_M},{lat},{lon});
 );
 out body;
@@ -73,7 +73,7 @@ def has_match(elements):
         return False, False
     for way in ways:
         sport = way.get("tags", {}).get("sport", "")
-        if sport in GAA_TAGS:
+        if any(tag in sport for tag in GAA_TAGS):
             return True, True
     return True, False  # matched but only via generic leisure=pitch
 

--- a/scripts/enrich_pitch_osm_data.py
+++ b/scripts/enrich_pitch_osm_data.py
@@ -186,13 +186,13 @@ def build_overpass_query(lat, lon, radius=SEARCH_RADIUS_M):
     return f"""
 [out:json][timeout:25];
 (
-  way["sport"="gaelic_football"](around:{radius},{lat},{lon});
-  way["sport"="hurling"](around:{radius},{lat},{lon});
-  way["sport"="gaelic_games"](around:{radius},{lat},{lon});
+  way["sport"~"gaelic_football"](around:{radius},{lat},{lon});
+  way["sport"~"hurling"](around:{radius},{lat},{lon});
+  way["sport"~"gaelic_games"](around:{radius},{lat},{lon});
   way["leisure"="pitch"](around:{radius},{lat},{lon});
-  relation["sport"="gaelic_football"](around:{radius},{lat},{lon});
-  relation["sport"="hurling"](around:{radius},{lat},{lon});
-  relation["sport"="gaelic_games"](around:{radius},{lat},{lon});
+  relation["sport"~"gaelic_football"](around:{radius},{lat},{lon});
+  relation["sport"~"hurling"](around:{radius},{lat},{lon});
+  relation["sport"~"gaelic_games"](around:{radius},{lat},{lon});
   relation["leisure"="pitch"](around:{radius},{lat},{lon});
 );
 out body;
@@ -263,7 +263,7 @@ def pick_best_element(elements, centroid_lat, centroid_lon):
         """Lower is better. GAA-specific tags get priority, then distance."""
         tags = way.get("tags", {})
         sport = tags.get("sport", "")
-        is_gaa = sport in gaa_tags
+        is_gaa = any(tag in sport for tag in gaa_tags)
         # Compute centroid of way nodes
         coords = [node_lookup[nid] for nid in way["nodes"] if nid in node_lookup]
         if not coords:


### PR DESCRIPTION
## Summary

- Pitches tagged with multiple sports on OSM (e.g. `sport=gaelic_games;field_hockey`) were being missed because Overpass `=` is an exact match operator
- Switch queries to use `~` (regex/substring match) in both scripts
- Also fix the Python-side check to use `any(tag in sport ...)` instead of `sport in GAA_TAGS`

Affects both `scripts/check_osm_coverage.py` and `scripts/enrich_pitch_osm_data.py`.

Spotted via St. Mary's GAA Aghagallon (Antrim) which has `sport=gaelic_games;field_hockey`.

## Test plan

- [x] Re-run `python3 scripts/check_osm_coverage.py Antrim` and verify St. Mary's GAA Aghagallon moves from `matched_generic` to `matched_gaa`

🤖 Generated with [Claude Code](https://claude.com/claude-code)