### PR TITLE
adding new magheracloone pitch

### DIFF
--- a/gaapitchfinder_data.csv
+++ b/gaapitchfinder_data.csv
@@ -1328,7 +1328,8 @@ Ireland,Inniskeen Grattans,Páirc Mhig Reachtain,,53.992989,-6.604538,Ulster,Ire
 Ireland,Kileevan Sarsfields,Sarsfields Park,,54.164385,-7.142703,Ulster,Ireland,Monaghan,Monaghan,"https://maps.google.com/?daddr=54.164385,-7.142703",https://twitter.com/killeevangaa,92.0,987.7,264.0
 Ireland,Killanny Geraldines,Páirc Eanna,,53.963288,-6.64651,Ulster,Ireland,Monaghan,Monaghan,"https://maps.google.com/?daddr=53.963288,-6.64651",https://twitter.com/killannygfc,32.0,838.2,243.0
 Ireland,Latton O'Rahillys,Páirc O'Raithile,,54.07299,-6.94884,Ulster,Ireland,Monaghan,Monaghan,"https://maps.google.com/?daddr=54.07299,-6.94884",https://twitter.com/LattonGAA,153.0,946.1,260.0
-Ireland,Magheracloone Mitchells,Kevin O'Reilly Park,,53.94452,-6.769294,Ulster,Ireland,Monaghan,Monaghan,"https://maps.google.com/?daddr=53.94452,-6.769294",https://twitter.com/mitchellsgaa_,51.0,912.9,260.0
+Ireland,Magheracloone Mitchells,Kevin O'Reilly Park (Old),,53.94452,-6.769294,Ulster,Ireland,Monaghan,Monaghan,"https://maps.google.com/?daddr=53.94452,-6.769294",https://twitter.com/mitchellsgaa_,51.0,912.9,260.0
+Ireland,Magheracloone Mitchells,Kevin O'Reilly Park,,53.93887,-6.771229,Ulster,Ireland,Monaghan,Monaghan,"https://maps.google.com/?daddr=53.93887,-6.771229",https://twitter.com/mitchellsgaa_,51.0,912.9,260.0
 Ireland,Monaghan Harps,Gavan Duffy Park,,54.249193,-6.96148,Ulster,Ireland,Monaghan,Monaghan,"https://maps.google.com/?daddr=54.249193,-6.96148",https://twitter.com/monaghanharps,55.0,919.7,264.0
 Ireland,Oram Sarsfields,Páirc Pádraig,,54.146262,-6.6955,Ulster,Ireland,Monaghan,Monaghan,"https://maps.google.com/?daddr=54.146262,-6.6955",https://twitter.com/oramgfc,120.0,1023.4,263.0
 Ireland,Rockcorry ,Páirc Muire,,54.119202,-7.012869,Ulster,Ireland,Monaghan,Monaghan,"https://maps.google.com/?daddr=54.119202,-7.012869",https://twitter.com/rockcorrygaa,88.0,946.1,260.0


### PR DESCRIPTION
Old pitch hit by [sinkhole](https://www.independent.ie/sport/gaelic-games/four-years-ago-a-sinkhole-destroyed-their-pitch-last-saturday-football-returned-to-magheracloone/41925452.html) - adding new one in this PR