### PR TITLE
Stop the HTTPS redirect from breaking local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ python3 scripts/generate_club_pages.py
 
 GitHub Actions runs this generator automatically before deploying `site/`, so production builds do not need `site/data.json` committed.
 
-For local static testing, generate the data file and serve the site directory:
+For local static testing over plain HTTP, generate the data file and serve the site directory:
 
 ```bash
 python3 scripts/generate_map_data.py
@@ -71,7 +71,7 @@ python3 scripts/audit_site.py
 python3 -m http.server 8000 --directory site
 ```
 
-Then open `http://localhost:8000`.
+Then open `http://localhost:8000`. HTTPS is provided by the production host, not the local Python server.
 
 ## Setup
 

--- a/site/js/ga.js
+++ b/site/js/ga.js
@@ -1,7 +1,3 @@
-if (location.protocol === "http:") {
-  location.replace("https://" + location.host + location.pathname + location.search + location.hash);
-}
-
 window.dataLayer = window.dataLayer || [];
 function gtag() {
   dataLayer.push(arguments);

--- a/tests/test_google_analytics.py
+++ b/tests/test_google_analytics.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GA_SCRIPT = ROOT / "site" / "js" / "ga.js"
+README = ROOT / "README.md"
+
+
+class GoogleAnalyticsScriptTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.script = GA_SCRIPT.read_text(encoding="utf-8")
+
+    def test_http_pages_are_not_redirected(self):
+        self.assertNotRegex(self.script, r"\blocation\.replace\s*\(")
+        self.assertNotRegex(
+            self.script, r"\blocation\.protocol\s*===?\s*[\"']http:[\"']"
+        )
+
+    def test_google_analytics_initialization_is_preserved(self):
+        self.assertIn("window.dataLayer = window.dataLayer || [];", self.script)
+        self.assertIn("dataLayer.push(arguments);", self.script)
+        self.assertIn('gtag("js", new Date());', self.script)
+        self.assertIn('gtag("config", "G-8R6YMPVNWH");', self.script)
+
+    def test_readme_documents_plain_http_development(self):
+        readme = README.read_text(encoding="utf-8")
+
+        self.assertIn("python3 -m http.server 8000 --directory site", readme)
+        self.assertIn("Then open `http://localhost:8000`.", readme)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Remove the client-side redirect that forced every HTTP URL to HTTPS.
- Clarify local HTTP and production HTTPS behavior in the README.
- Add regression coverage for the analytics script.

## Root cause

The analytics bootstrap redirected any page using the `http:` protocol, including local development servers that do not provide HTTPS.

## Impact

Local development works over ordinary HTTP again. Production remains HTTPS through GitHub Pages without JavaScript rewriting the current location.

## Validation

- `python -m unittest tests.test_google_analytics -v`
- `python -m unittest discover -s tests -v`
- `git diff --check`

Closes #109
